### PR TITLE
Remove CRTM from being built inline

### DIFF
--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -24,9 +24,6 @@
 - iodaconv:
     repo_url_name: ioda-converters
     default_branch: develop
-- crtm:
-    default_branch: v2.4-jedi
-    tag: True
 - geos-aero:
     default_branch: develop
 - gsw:

--- a/src/jedi_bundle/config/bundles/fv3-jedi.yaml
+++ b/src/jedi_bundle/config/bundles/fv3-jedi.yaml
@@ -4,7 +4,6 @@ optional_repos:
 
 required_repos:
   - jedicmake
-  - crtm
   - oops
   - saber
   - ioda

--- a/src/jedi_bundle/config/bundles/soca.yaml
+++ b/src/jedi_bundle/config/bundles/soca.yaml
@@ -1,6 +1,3 @@
-optional_repos:
-  - crtm
-
 required_repos:
   - jedicmake
   - oops

--- a/src/jedi_bundle/config/bundles/ufo.yaml
+++ b/src/jedi_bundle/config/bundles/ufo.yaml
@@ -7,7 +7,6 @@ required_repos:
   - jedicmake
   - oops
   - ioda
-  - crtm
   - ufo
   - ioda-data
   - ufo-data

--- a/src/jedi_bundle/config/platforms/discover.yaml
+++ b/src/jedi_bundle/config/platforms/discover.yaml
@@ -1,8 +1,9 @@
 modules:
   default_modules: intel
   intel:
-    load:
+    init:
       - source /usr/share/lmod/lmod/init/bash
+    load:
       - module purge
       - module use /discover/swdev/jcsda/spack-stack/modulefiles
       - module load miniconda/3.9.7
@@ -17,8 +18,9 @@ modules:
       - module load sp/2.3.3
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.5.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
-    load:
+    init:
       - source /usr/share/lmod/lmod/init/bash
+    load:
       - module purge
       - module use /discover/swdev/jcsda/spack-stack/modulefiles
       - module load miniconda/3.9.7

--- a/src/jedi_bundle/configure_jedi_bundle.py
+++ b/src/jedi_bundle/configure_jedi_bundle.py
@@ -43,8 +43,16 @@ def configure_jedi(logger, configure_config):
 
         # Steps to load the chosen modules
         modules_dict = platform_dict['modules'][modules]
+        module_inits = config_get(logger, modules_dict, 'init', [])
         module_directives = config_get(logger, modules_dict, 'load')
         platform_configure_directives = config_get(logger, modules_dict, 'configure', '')
+
+        # Create modules init file
+        modules_init = os.path.join(path_to_build, 'modules-init')
+        remove_file(logger, modules_init)
+        with open(modules_init, 'a') as modules_init_open:
+            for module_init in module_inits:
+                modules_init_open.write(module_init + '\n')
 
         # Create modules file
         modules_file = os.path.join(path_to_build, 'modules')
@@ -67,6 +75,7 @@ def configure_jedi(logger, configure_config):
         configure_file_open.write(f'#!/usr/bin/env bash \n')
         configure_file_open.write(f'\n')
         if platform != 'none':
+            configure_file_open.write(f'source {modules_init}\n')
             configure_file_open.write(f'source {modules_file}\n')
         configure_file_open.write(f'\n')
         configure_file_open.write(f'{ecbuild} \n')

--- a/src/jedi_bundle/make_jedi_bundle.py
+++ b/src/jedi_bundle/make_jedi_bundle.py
@@ -30,6 +30,7 @@ def make_jedi(logger, make_config):
 
     # Modules file
     if modules != 'none':
+        modules_init = os.path.join(path_to_build, 'modules-init')
         modules_file = os.path.join(path_to_build, 'modules')
 
     # File to hold configure steps
@@ -49,6 +50,7 @@ def make_jedi(logger, make_config):
             make_file_open.write(f'#!/usr/bin/env bash \n')
             make_file_open.write(f'\n')
             if modules != 'none':
+                make_file_open.write(f'source {modules_init} \n')
                 make_file_open.write(f'source {modules_file} \n')
             make_file_open.write(f'\n')
             make_file_open.write(f'make -j{cores_to_use_for_make} \n')


### PR DESCRIPTION
## Description

Remove CRTM from being built since it is part of spack-stack now.

Also split off the initialization of the modules so the modules file can be sourced with cshell
