### PR TITLE
Do not clone jedicmake at clone time

### DIFF
--- a/src/jedi_bundle/__init__.py
+++ b/src/jedi_bundle/__init__.py
@@ -9,4 +9,4 @@ import os
 build_directory = os.path.dirname(__file__)
 
 # Set the version for jedi_bundle
-__version__ = '1.0.8'
+__version__ = '1.0.9'

--- a/src/jedi_bundle/clone_jedi_bundle.py
+++ b/src/jedi_bundle/clone_jedi_bundle.py
@@ -160,8 +160,13 @@ def clone_jedi(logger, clone_config):
     # --------------
     for repo, url, branch, is_tag in zip(repo_list, url_list, branch_list, is_tag_list):
 
-        logger.info(f'Cloning \'{repo}\'.')
-        clone_git_repo(logger, url, branch, os.path.join(path_to_source, repo), is_tag)
+        # Special treatment for jedicmake since it is typically part of spack.
+        if repo == 'jedicmake':
+            logger.info(f'Skipping explicit clone of \'{repo}\' since it\'s usually a module. ' +
+                        f'If it\'s not a module it will be cloned at configure time.')
+        else:
+            logger.info(f'Cloning \'{repo}\'.')
+            clone_git_repo(logger, url, branch, os.path.join(path_to_source, repo), is_tag)
 
     # Create CMakeLists.txt file
     # --------------------------


### PR DESCRIPTION
## Description

Do not clone jedicmake. It is almost always part of spack-stack. If it is not the user can always fall back on cloning it at ecbuild configure time.

## Dependencies

N/A

