### PR TITLE
Allow for Icepack with Soca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # System files
 *.swp
+._*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/jedi_bundle/__init__.py
+++ b/src/jedi_bundle/__init__.py
@@ -9,4 +9,4 @@ import os
 build_directory = os.path.dirname(__file__)
 
 # Set the version for jedi_bundle
-__version__ = '1.0.14'
+__version__ = '1.0.15'

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -19,6 +19,8 @@
     default_branch: develop
 
 # Observation operators
+- ioda-data:
+    default_branch: develop
 - ioda:
     default_branch: develop
 - iodaconv:
@@ -34,6 +36,11 @@
     repo_url_name: ropp-test
 - rttov:
     default_branch: develop
+- crtm:
+    default_branch: v2.4-jedi.2
+    tag: true
+- ufo-data:
+    default_branch: develop
 - ufo:
     default_branch: develop
 
@@ -47,6 +54,9 @@
     default_branch: release-stable
 
 # Soca
+- icepack:
+    repo_url_name: Icepack
+    default_branch: feature/ecbuild-new
 - mom6:
     repo_url_name: MOM6
     default_branch: main-ecbuild
@@ -62,13 +72,7 @@
     default_branch: develop
 - femps:
     default_branch: develop
-- fv3-jedi:
-    default_branch: develop
-
-# Test data
 - fv3-jedi-data:
     default_branch: develop
-- ufo-data:
-    default_branch: develop
-- ioda-data:
+- fv3-jedi:
     default_branch: develop

--- a/src/jedi_bundle/config/bundles/fv3-jedi.yaml
+++ b/src/jedi_bundle/config/bundles/fv3-jedi.yaml
@@ -8,6 +8,7 @@ required_repos:
   - gsibec
   - saber
   - ioda
+  - crtm
   - ufo
   - vader
   - fms

--- a/src/jedi_bundle/config/bundles/soca.yaml
+++ b/src/jedi_bundle/config/bundles/soca.yaml
@@ -1,5 +1,6 @@
 optional_repos:
   - crtm
+  - icepack
 
 required_repos:
   - jedicmake
@@ -11,7 +12,6 @@ required_repos:
   - ufo
   - vader
   - fms
-  - icepack
   - mom6
   - soca
   - ioda-data

--- a/src/jedi_bundle/config/bundles/soca.yaml
+++ b/src/jedi_bundle/config/bundles/soca.yaml
@@ -1,3 +1,6 @@
+optional_repos:
+  - crtm
+
 required_repos:
   - jedicmake
   - oops
@@ -8,6 +11,7 @@ required_repos:
   - ufo
   - vader
   - fms
+  - icepack
   - mom6
   - soca
   - ioda-data

--- a/src/jedi_bundle/config/bundles/ufo.yaml
+++ b/src/jedi_bundle/config/bundles/ufo.yaml
@@ -2,6 +2,7 @@ optional_repos:
   - ropp-ufo
   - geos-aero
   - gsw
+  - crtm
 
 required_repos:
   - jedicmake

--- a/src/jedi_bundle/config/platforms/discover.yaml
+++ b/src/jedi_bundle/config/platforms/discover.yaml
@@ -16,9 +16,7 @@ modules:
       - module load jedi-fv3-env/unified-dev
       - module load ewok-env/unified-dev
       - module load soca-env/unified-dev
-      - module unload gsibec
-      - module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/compiler/intel/2022.0.1
-      - module load crtm/v2.4-jedi.2
+      - module unload gsibec crtm
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.5.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
     init:
@@ -36,7 +34,5 @@ modules:
       - module load jedi-fv3-env/unified-dev
       - module load ewok-env/unified-dev
       - module load soca-env/unified-dev
-      - module unload gsibec
-      - module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/compiler/gnu/10.1.0
-      - module load crtm/v2.4-jedi.2
+      - module unload gsibec crtm
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/configure_jedi_bundle.py
+++ b/src/jedi_bundle/configure_jedi_bundle.py
@@ -67,7 +67,8 @@ def configure_jedi(logger, configure_config):
 
     # ecbuild command
     ecbuild = f'ecbuild --build={cmake_build_type} {platform_configure_directives} ' + \
-              f'{custom_configure_options} {path_to_source}'
+              f'{custom_configure_options} -DENABLE_IODA_DATA=ON -DENABLE_UFO_DATA=ON ' + \
+              f'-DENABLE_FV3_JEDI_DATA=ON {path_to_source}'
     logger.info(f'Running configure with \'{ecbuild}\'')
 
     # Write steps to file


### PR DESCRIPTION
## Description

- Allow for Icepack with Soca
- Build CRTM in the bundle (like JCSDA do) and allow for Soca to optionally build with CRTM
- Updates similar to https://github.com/JCSDA-internal/jedi-bundle/pull/71

## Dependencies

N/A

## Impact

N/A
