### PR TITLE
update crtm version for test-data download compatability

### DIFF
--- a/src/jedi_bundle/config/platforms/nccs_discover.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover.yaml
@@ -5,7 +5,7 @@ is_it_me:
   - command: 'cat /etc/os-release | grep VERSION='
     contains: '12-'
 crtm_coeffs_path: '/discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/'
-crtm_coeffs_version: '2.4.0_skylab_3.0'
+crtm_coeffs_version: '2.4.1_skylab_4.0'
 modules:
   default_modules: intel
   intel:

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -5,7 +5,7 @@ is_it_me:
   - command: 'cat /etc/os-release | grep VERSION='
     contains: '15-'
 crtm_coeffs_path: '/discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/'
-crtm_coeffs_version: '2.4.0_skylab_3.0'
+crtm_coeffs_version: '2.4.1_skylab_4.0'
 modules:
   default_modules: intel
   intel:


### PR DESCRIPTION
Has to conform with:

https://github.com/JCSDA-internal/ufo/blob/fc956f44b6bf044ba835a9c320e97d1a5a373060/CMakeLists.txt#L151-L157

This only impacts what CRTM version we pull for UFO test-data but doesn't impact what we are using.