### PR TITLE
Add module entries for spack-built GEOS work

### DIFF
--- a/src/jedi_bundle/config/platforms/nccs_discover.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover.yaml
@@ -26,6 +26,25 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.6.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  intel-geos:
+    init:
+      - source /usr/share/lmod/lmod/init/bash
+    load:
+      - module purge
+      - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
+      - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
+      - module load miniconda/3.9.7
+      - module load ecflow/5.8.4
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
+      - module load stack-intel/2021.6.0
+      - module load stack-intel-oneapi-mpi/2021.6.0
+      - module load stack-python/3.10.13
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload gsibec crtm
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
+    configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.6.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
     init:
       - source /usr/share/lmod/lmod/init/bash
@@ -43,4 +62,23 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
+  gnu-geos:
+    init:
+      - source /usr/share/lmod/lmod/init/bash
+    load:
+      - module purge
+      - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
+      - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
+      - module load miniconda/3.9.7
+      - module load ecflow/5.8.4
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-gcc-12.1.0/install/modulefiles/Core
+      - module load stack-gcc/12.1.0
+      - module load stack-openmpi/4.1.3
+      - module load stack-python/3.10.13
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload gsibec crtm
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -25,6 +25,24 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  intel-geos:
+    init:
+      - source /usr/share/lmod/lmod/init/bash
+    load:
+      - module purge
+      - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
+      - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
+      - module load ecflow/5.11.4
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+      - module load stack-intel/2021.10.0
+      - module load stack-intel-oneapi-mpi/2021.10.0
+      - module load stack-python/3.10.13
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload gsibec crtm
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
+    configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
     init:
       - source /usr/share/lmod/lmod/init/bash
@@ -41,4 +59,22 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
+  gnu-geos:
+    init:
+      - source /usr/share/lmod/lmod/init/bash
+    load:
+      - module purge
+      - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
+      - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
+      - module load ecflow/5.11.4
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module load stack-gcc/12.3.0
+      - module load stack-openmpi/4.1.6
+      - module load stack-python/3.10.13
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload gsibec crtm
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"


### PR DESCRIPTION
## Description

In trying to use a spack-built GEOSgcm, it was found that we need to load extra modules. I could not figure out how to do this other than hacking jedi_bundle. To be safe, I *added* two new `modules` entries, `intel-geos` and `gnu-geos` since I don't want to step and all it does is add:
```
- module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
```
to what's in `intel` and `geos`.

NOTE: I think these could just always be added to `intel` and `geos` but I am being safe here.

## Dependencies

None.

## Impact

I think this is pretty self contained, though I suppose the docs might need updating.
