### PR TITLE
Adding ability to update hashes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'jedi_bundle = jedi_bundle.bin.jedi_bundle:jedi_bundle',
+            'jedi_bundle_update_hash = \
+                 jedi_bundle.bin.jedi_bundle_update_hash:jedi_bundle_update_hash'
         ],
     },
     )

--- a/src/jedi_bundle/bin/jedi_bundle_update_hash.py
+++ b/src/jedi_bundle/bin/jedi_bundle_update_hash.py
@@ -9,7 +9,7 @@
 # --------------------------------------------------------------------------------------------------
 
 import argparse
-from datetime import datetime as dt
+from datetime import datetime, date, time, timezone
 from jedi_bundle.utils.logger import Logger
 from jedi_bundle.utils.update_hash import update_hash
 
@@ -23,12 +23,12 @@ def jedi_bundle_update_hash():
 
     logger = Logger('JediBundleUpdateHash')
     args = parser.parse_args()
-    date = args.date
+    input_date = args.date
 
     # Convert date to datetime object
-    dt_object = dt.strptime(date, '%Y-%m-%d').astimezone()
+    dt_object = datetime.combine(date.fromisoformat(input_date), time(0, 0, tzinfo=timezone.utc))
 
     # Call update hashes
     update_hash(logger, dt_object)
 
-    logger.info(f'Updated pinned_versions.yaml to latest commits before {date}')
+    logger.info(f'Updated pinned_versions.yaml to latest commits before {input_date}')

--- a/src/jedi_bundle/bin/jedi_bundle_update_hash.py
+++ b/src/jedi_bundle/bin/jedi_bundle_update_hash.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2022 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+import argparse
+from datetime import datetime as dt
+from jedi_bundle.utils.logger import Logger
+from jedi_bundle.utils.update_hash import update_hash
+
+
+def jedi_bundle_update_hash():
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('date', type=str,
+                        help='Provide a date using YYYY-MM-DD format to update pinned versions \n'
+                             'to the latest commit hashes before the provided date')
+
+    logger = Logger('JediBundleUpdateHash')
+    args = parser.parse_args()
+    date = args.date
+
+    # Convert date to datetime object
+    dt_object = dt.strptime(date, '%Y-%m-%d').astimezone()
+
+    # Call update hashes
+    update_hash(logger, dt_object)
+
+    logger.info(f'Updated pinned_versions.yaml to latest commits before {date}')

--- a/src/jedi_bundle/clone_jedi_bundle.py
+++ b/src/jedi_bundle/clone_jedi_bundle.py
@@ -229,10 +229,8 @@ def clone_jedi(logger, clone_config):
         elif repo == 'fv3':
             logger.info('Cloning fv3-interface.cmake from the jedi-bundle repo for fv3')
             found, url_tmp, branch_tmp, \
-                is_tag, is_commit = get_url_and_branch(logger, github_orgs, 'jedi-bundle',
-                                                       default_branch, user_branch,
-                                                       False, False)
-
+                _, _ = get_url_and_branch(logger, github_orgs, 'jedi-bundle',
+                                          'develop', user_branch, False, False)
             clone_git_file(logger, url_tmp, ['fv3-interface.cmake'], path_to_source, depth=1)
             logger.info('Cloning fv3.')
             clone_git_repo(logger, url, branch,

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -70,8 +70,6 @@
     default_branch: develop
 - fv3-jedi:
     default_branch: develop
-#- jedi-bundle:
-#    default_branch: develop
 
 # Other external packages
 - da-utils:

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -70,8 +70,8 @@
     default_branch: develop
 - fv3-jedi:
     default_branch: develop
-- jedi-bundle:
-    default_branch: develop
+#- jedi-bundle:
+#    default_branch: develop
 
 # Other external packages
 - da-utils:

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,5 +1,5 @@
-# Saved pinned versions from 2024-7-28
-# Updated pinned versions will be found in JediOpt/core
+# Saved pinned versions from 2024-7-30
+# Updated pinned versions will be found in core directory
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
@@ -18,9 +18,6 @@
 - vader:
     branch: 36dac46ac170ef8f80c2f147d0a8db7bfd9aba3c
     commit: true
-#- jedi-bundle:
-#    branch: ec768119e250e7156c4f3a63e5a4fadc0441efee
-#    commit: true
 - fv3:
     branch: ab25dc09d955271f34ca6a3fa83af1093c85d9f7
     commit: true
@@ -54,9 +51,3 @@
 - icepack:
     branch: 73136ee8dcdbe378821e540488a5980a03d8abe6
     commit: true
-#- fms:
-#    branch: 1f739141ef8b000a0bd75ae8bebfadea340299ba
-#    commit: true
-#- mom6:
-#    branch: 51ec489ad7d8a86762bef4c46eabd9af5fc41fa4
-#    commit: true

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -18,9 +18,9 @@
 - vader:
     branch: 36dac46ac170ef8f80c2f147d0a8db7bfd9aba3c
     commit: true
-- jedi-bundle:
-    branch: ec768119e250e7156c4f3a63e5a4fadc0441efee
-    commit: true
+#- jedi-bundle:
+#    branch: ec768119e250e7156c4f3a63e5a4fadc0441efee
+#    commit: true
 - fv3:
     branch: ab25dc09d955271f34ca6a3fa83af1093c85d9f7
     commit: true
@@ -54,9 +54,9 @@
 - icepack:
     branch: 73136ee8dcdbe378821e540488a5980a03d8abe6
     commit: true
-- fms:
-    branch: 1f739141ef8b000a0bd75ae8bebfadea340299ba
-    commit: true
-- mom6:
-    branch: 51ec489ad7d8a86762bef4c46eabd9af5fc41fa4
-    commit: true
+#- fms:
+#    branch: 1f739141ef8b000a0bd75ae8bebfadea340299ba
+#    commit: true
+#- mom6:
+#    branch: 51ec489ad7d8a86762bef4c46eabd9af5fc41fa4
+#    commit: true

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,5 +1,4 @@
-# Saved pinned versions from 2024-7-30
-# Updated pinned versions will be found in core directory
+# Pinned versions for 2024-07-30
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
@@ -7,7 +6,7 @@
     branch: e6485c0a659103f0daa2b7e2cece39a15bfb0d60
     commit: true
 - saber:
-    branch: 1c0a24d96b9c4560d53d689078487c68a34e8037
+    branch: e93b14ff97acc70cdbb6bdd57620da2cc81c5eb0
     commit: true
 - ioda:
     branch: c7b8760fc187a9eafb72a466d16fdee284912377
@@ -40,7 +39,7 @@
     branch: 92519ab72b89a4c3b802501e71b7b66349fc8cc8
     commit: true
 - iodaconv:
-    branch: 8ae8581f72d9a50cd9f589e1a858b0c562e2da52
+    branch: e8235068c663029b1f2cb4abf4e86f476c2e6af0
     commit: true
 - gsw:
     branch: 697cbeb7605d70ed3857664c5f54a5c05346e31f

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,45 +1,62 @@
+# Saved pinned versions from 2024-7-28
+# Updated pinned versions will be found in JediOpt/core
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
 - oops:
-    branch: 78aaed70799a2e2a33175f132adb113d3c38720e
-    commit: true
-- gsibec:
-    branch: 606042920c33bcb89e408e918e7bdcfd95537c9f
+    branch: e6485c0a659103f0daa2b7e2cece39a15bfb0d60
     commit: true
 - saber:
-    branch: a4caa3a676d49278b271a43d2993265026ad0afb
+    branch: 1c0a24d96b9c4560d53d689078487c68a34e8037
     commit: true
 - ioda:
-    branch: 27d0b0c8e541d1ba759b5a576e934e8f3a350d46
-    commit: true
-- crtm:
-    branch: 8783a51222ad20a48c4251406e236d6032535543
+    branch: c7b8760fc187a9eafb72a466d16fdee284912377
     commit: true
 - ufo:
-    branch: 130c1848de9f03b145b3ba303dc308ff8b90dd11
+    branch: cd66505007b1559d79cb158bd6dc018a3943c1e7
     commit: true
 - vader:
-    branch: 469bc0446472e7703fab46c72b5710a8bac17456
+    branch: 36dac46ac170ef8f80c2f147d0a8db7bfd9aba3c
     commit: true
 - jedi-bundle:
-    branch: e2343e59cfd85f27935122bdfcc8e618d9be01e4
+    branch: ec768119e250e7156c4f3a63e5a4fadc0441efee
     commit: true
 - fv3:
-    branch: 0dd21f5426b602a698f5dfd73b44da3a62c81fe4
+    branch: ab25dc09d955271f34ca6a3fa83af1093c85d9f7
     commit: true
 - fv3-jedi-lm:
-    branch: af67095ee87ffb472218aa386e34c6bfe64ca424
+    branch: a6e97d76ed7c0b2a27cf97512893a93d7e2b44bc
     commit: true
 - femps:
     branch: 4f12677d345e683bf910b5f76f0df120ad27482d
     commit: true
 - fv3-jedi:
-    branch: 46f172dfeb9aacb1b4c14a91fb149f22b41f3343
+    branch: d3c800b82eef8d1eaadcbc07c3cf7a96d8425233
     commit: true
 - ioda-data:
-    branch: da8c9fe55a88b37d36bc1c43e7fb05a1742cb39f
+    branch: a8c2bb3265ee2ab222706d606d22282630810750
     commit: true
 - fv3-jedi-data:
-    branch: 3d318b4778188e919a5ba87d6c78148af2cedc33
+    branch: dd0524e339250c0b80858812f2d85cceedbf07ee
+    commit: true
+- soca:
+    branch: 92519ab72b89a4c3b802501e71b7b66349fc8cc8
+    commit: true
+- iodaconv:
+    branch: 8ae8581f72d9a50cd9f589e1a858b0c562e2da52
+    commit: true
+- gsw:
+    branch: 697cbeb7605d70ed3857664c5f54a5c05346e31f
+    commit: true
+- ufo-data:
+    branch: 70464f6da0c306828d820004375d151c33c7c53d
+    commit: true
+- icepack:
+    branch: 73136ee8dcdbe378821e540488a5980a03d8abe6
+    commit: true
+- fms:
+    branch: 1f739141ef8b000a0bd75ae8bebfadea340299ba
+    commit: true
+- mom6:
+    branch: 51ec489ad7d8a86762bef4c46eabd9af5fc41fa4
     commit: true

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,3 +1,45 @@
+- jedicmake:
+    branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
+    commit: true
+- oops:
+    branch: 78aaed70799a2e2a33175f132adb113d3c38720e
+    commit: true
+- gsibec:
+    branch: 606042920c33bcb89e408e918e7bdcfd95537c9f
+    commit: true
+- saber:
+    branch: a4caa3a676d49278b271a43d2993265026ad0afb
+    commit: true
+- ioda:
+    branch: 27d0b0c8e541d1ba759b5a576e934e8f3a350d46
+    commit: true
+- crtm:
+    branch: 8783a51222ad20a48c4251406e236d6032535543
+    commit: true
 - ufo:
-    branch: 64655cf61a9d22c88c0f20e740554ca5225790bc
-    commit: True
+    branch: 130c1848de9f03b145b3ba303dc308ff8b90dd11
+    commit: true
+- vader:
+    branch: 469bc0446472e7703fab46c72b5710a8bac17456
+    commit: true
+- jedi-bundle:
+    branch: e2343e59cfd85f27935122bdfcc8e618d9be01e4
+    commit: true
+- fv3:
+    branch: 0dd21f5426b602a698f5dfd73b44da3a62c81fe4
+    commit: true
+- fv3-jedi-lm:
+    branch: af67095ee87ffb472218aa386e34c6bfe64ca424
+    commit: true
+- femps:
+    branch: 4f12677d345e683bf910b5f76f0df120ad27482d
+    commit: true
+- fv3-jedi:
+    branch: 46f172dfeb9aacb1b4c14a91fb149f22b41f3343
+    commit: true
+- ioda-data:
+    branch: da8c9fe55a88b37d36bc1c43e7fb05a1742cb39f
+    commit: true
+- fv3-jedi-data:
+    branch: 3d318b4778188e919a5ba87d6c78148af2cedc33
+    commit: true

--- a/src/jedi_bundle/utils/git.py
+++ b/src/jedi_bundle/utils/git.py
@@ -80,8 +80,6 @@ def repo_has_branch(
         r = requests.get(commit_url)
         if r.ok:
             logger.info(f'Found commit at {commit_url}')
-        else:
-            logger.info(f'Cannot find commit at {commit_url}')
         return r.ok
 
     # Command to check if branch exists and pass exit code back

--- a/src/jedi_bundle/utils/git.py
+++ b/src/jedi_bundle/utils/git.py
@@ -184,7 +184,7 @@ def clone_git_repo(logger, url, branch, target, is_tag, is_commit):
 
         if is_commit:
 
-            git_clone_cmd = ['git', 'clone', url, target]
+            git_clone_cmd = ['git', 'clone', '--recursive', url, target]
             subprocess_run(logger, git_clone_cmd, True)
             git_checkout_cmd = ['git', 'checkout', branch]
             subprocess_run(logger, git_checkout_cmd, True, cwd=target)

--- a/src/jedi_bundle/utils/update_hash.py
+++ b/src/jedi_bundle/utils/update_hash.py
@@ -89,3 +89,5 @@ def update_hash(logger: Logger, date: dt) -> None:
     # Update pinned_versions.yaml
     with open(path_to_pinned_versions, 'w') as out:
         yaml.dump(pinned_versions, out)
+
+    logger.info(f'pinned_versions.yaml updated at {path_to_pinned_versions}')

--- a/src/jedi_bundle/utils/update_hash.py
+++ b/src/jedi_bundle/utils/update_hash.py
@@ -1,0 +1,84 @@
+import os
+import yaml
+import requests
+from datetime import datetime as dt
+from jedi_bundle.utils.yaml import load_yaml
+from jedi_bundle.utils.logger import Logger
+from jedi_bundle.utils.git import get_github_username_token
+from jedi_bundle.config.config import return_config_path
+
+
+def update_hash(logger: Logger, date: dt) -> None:
+
+    # Load pinned versions for repo list
+    path_to_pinned_versions = os.path.join(return_config_path(), 'pinned_versions.yaml')
+    pinned_versions = load_yaml(logger, 'pinned_versions.yaml')
+
+    # Load build order from jedi_bundle for repo aliases
+    aliases = load_yaml(logger, os.path.join(return_config_path(), 'bundles', 'build-order.yaml'))
+
+    # Get git credentials ready
+    _, token = get_github_username_token(logger)
+
+    urls = [f'https://api.github.com/repos/jcsda-internal/',
+            f'https://api.github.com/repos/geos-esm/',
+            f'https://api.github.com/repos/jcsda/']
+
+    # Update each repo commit hash if applicable
+    for i in range(len(pinned_versions)):
+        repo_alias = ''
+        repo_dict = pinned_versions[i]
+        repo_name = list(repo_dict.keys())[0]
+
+        # convert name to repo alias if needed
+        for j in range(len(aliases)):
+            if repo_name in aliases[j]:
+                if 'repo_url_name' in aliases[j][repo_name]:
+                    repo_alias = aliases[j][repo_name]['repo_url_name']
+                    break
+
+        if 'commit' in repo_dict[repo_name]:
+            if repo_dict[repo_name]['commit']:
+
+                auth_header = {
+                    'Authorization': f'token {token}',
+                }
+
+                for url in urls:
+                    if repo_alias:
+                        url += f'{repo_alias}/commits'
+                    else:
+                        url += f'{repo_name}/commits'
+                    response = requests.get(url, headers=auth_header)
+                    data = response.json()
+                    if isinstance(data, list):
+                        break
+
+                if isinstance(data, dict):
+                    logger.abort(f'Failed to retrieve commit history for {repo_name} from {urls}')
+
+                # Perform search to find first commit earlier than date provided
+                left, right = 0, len(data) - 1
+                while left < right:
+                    mid = (left + right) // 2
+                    curr_date = dt.strptime(data[mid]['commit']['author']['date'],
+                                            '%Y-%m-%dT%H:%M:%S%z')
+                    if curr_date < date:
+                        right = mid
+                    else:
+                        left = mid + 1
+
+                # Throw error if commit previous to given date cannot be found
+                curr_date = dt.strptime(data[left]['commit']['author']['date'],
+                                        '%Y-%m-%dT%H:%M:%S%z')
+                if curr_date > date:
+                    logger.abort(f'Unable to find commit with date before {date}')
+
+                # Update repo dict with new commit hash
+                updated_commit = data[left]['sha']
+                pinned_versions[i][repo_name]['branch'] = updated_commit
+                logger.info(f'{repo_name}, date: {curr_date}, hash: {updated_commit}')
+
+    # Update pinned_versions.yaml
+    with open(path_to_pinned_versions, 'w') as out:
+        yaml.dump(pinned_versions, out)

--- a/src/jedi_bundle/utils/update_hash.py
+++ b/src/jedi_bundle/utils/update_hash.py
@@ -87,6 +87,5 @@ def update_hash(logger: Logger, date: dt) -> None:
                 logger.info(f'{name}/{default_branch}, date: {curr_date}, hash: {updated_commit}')
 
     # Update pinned_versions.yaml
-    print(path_to_pinned_versions)
     with open(path_to_pinned_versions, 'w') as out:
         yaml.dump(pinned_versions, out)

--- a/src/jedi_bundle/utils/update_hash.py
+++ b/src/jedi_bundle/utils/update_hash.py
@@ -61,8 +61,8 @@ def update_hash(logger: Logger, date: dt) -> None:
                         break
 
                 if isinstance(data, dict):
-                    logger.abort(f'Failed to retrieve commit history for \
-                                   {name}/{default_branch} from {urls}')
+                    logger.abort('Failed to retrieve commit history for '
+                                 f'{name}/{default_branch} from {urls}')
 
                 # Perform search to find first commit earlier than date provided
                 left, right = 0, len(data) - 1


### PR DESCRIPTION
## Description

Addresses discussion in https://github.com/GEOS-ESM/swell/issues/345.

This PR adds a tool to automatically update repositories with pinned versions based on an input date. Example of tool's interface:

```jedi_bundle_update_hash 2024-7-29```

This executable takes in a date with `%Y-%m-%d` format, retrieves commit histories for each repository/default_branch in `pinned-versions.yaml`, and then returns the commit hash for _the latest commit before the given date_. It will then update `pinned-versions.yaml` in the package's core directory with the updated hashes.

In order to see these pinned versions in the `build.yaml` file, add the pinned version flag:
```jedi_bundle -pv```. Then proceed as normal with `Clone`, `Configure`, and `Make`.


### Dependencies
- In order to test this PR completely, #41 needs to be merged.