### PR TITLE
Update modules to spack-stack 1.8 and change pinned versions

### DIFF
--- a/docs/_platforms/building_jedi_code_on_discover_sles12.md
+++ b/docs/_platforms/building_jedi_code_on_discover_sles12.md
@@ -31,7 +31,7 @@ jedi_bundle
 
 Before proceeding you may want to edit `build.yaml` to choose different options. It will default to building all bundles and you may wish to only build a specific bundle by modifying `clone_options.bundles`. Choosing `fv3-jedi` and `ufo`, for example, will result in building all the code for the `fv3-jedi` and `ufo` bundles. You may also want to change the modules used to build or change the type of build to use.
 
-Once `build.yaml` is configured they way you wish, you can issue `jedi_bundle` again with the tasks you want. 
+Once `build.yaml` is configured they way you wish, you can issue `jedi_bundle` again with the tasks you want.
 
 5) Clone & configure the JEDI repositories on a login node (clone & configure arguments can be issued seperately):
 
@@ -39,7 +39,7 @@ Once `build.yaml` is configured they way you wish, you can issue `jedi_bundle` a
 jedi_bundle clone configure build.yaml
 ```
 
-6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following:
+6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following (Note: 1 hour could be insufficient if Discover IO load is high. If that is the case simply request interactive nodes again and submit `make` command with the proper modules loaded):
 
 ``` bash
 salloc --time=1:00:00

--- a/docs/_platforms/building_jedi_code_on_discover_sles15.md
+++ b/docs/_platforms/building_jedi_code_on_discover_sles15.md
@@ -1,6 +1,6 @@
 # Building JEDI code on Discover (SLES 15)
 
-1) Load the JEDI spack Python modules (These modules will load Python version 3.10):
+1) Load the JEDI spack Python modules (These modules will load Python version 3.11):
 
 ``` bash
 module purge
@@ -11,7 +11,7 @@ source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/bundle-intel-sl
 
 ``` bash
 module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core/
-module load jedi_bundle/sles15_skylab7
+module load jedi_bundle/sles15_skylab8
 ```
 
 3) Create a directory where the source code and build directory will be stored e.g.:
@@ -37,7 +37,7 @@ Once `build.yaml` is configured they way you wish, you can issue `jedi_bundle` a
 jedi_bundle clone configure build.yaml
 ```
 
-6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following:
+6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following (Note: 1 hour could be insufficient if Discover IO load is high. If that is the case simply request interactive nodes again and submit `make` command with the proper modules loaded):
 
 ``` bash
 salloc --time=1:00:00

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,18 +1,18 @@
-# Pinned versions for 2024-08-31
+# Pinned versions for 2024-10-02
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
 - oops:
-    branch: d77217323bbbd02ea41049fe1bd339f24a64f177
+    branch: f099b356a89c93312556b99c75cab57861465351
     commit: true
 - saber:
-    branch: 524b6e5fcd7a490a82120c81e5d504b9d95d1575
+    branch: 31215817e579ef04d2a33fa2b57970e27ed77a59
     commit: true
 - ioda:
-    branch: ad84060522f6fa7ab9c75d227f1d9e72c8bf7a28
+    branch: 3fa4a997e25b3bd018d30e308a26b3e98af0fe6f
     commit: true
 - ufo:
-    branch: 58e7da419c80f8613e0af5105ecd7d09b75bdd3d
+    branch: 4c1524dcdb4b5a899f98e0dd8d6b283fd032f712
     commit: true
 - vader:
     branch: 6d56a1eb5b6b315c7b9befbda26896e783c07f78
@@ -27,25 +27,25 @@
     branch: 4f12677d345e683bf910b5f76f0df120ad27482d
     commit: true
 - fv3-jedi:
-    branch: a94bb3f9ec0d7c8d59dce64ea638753231f2e344
+    branch: 1e85af297c37c9dd3f3acd75b4bd8f944ee9f3de
     commit: true
 - ioda-data:
     branch: bcb0754f957f857c0ccc893f8402c384bc2e8ba8
     commit: true
 - fv3-jedi-data:
-    branch: 568088d9ec13f6ebb405008961d9c1f2913bbd95
+    branch: ccbdede59a5fc2f896f4a35fb49aaa7232d69724
     commit: true
 - soca:
-    branch: d260316b9c4e03b1f040fe6ede2fde152408f4a4
+    branch: 4d7ef21e74d78a065156c942a72806ef2e2eb08e
     commit: true
 - iodaconv:
-    branch: a7f5909c5753cdcec2dbcf5a4f836e9be7ce6160
+    branch: 23e58ed76da3628cbd508bd4ac40f8a01c789d7d
     commit: true
 - gsw:
     branch: 697cbeb7605d70ed3857664c5f54a5c05346e31f
     commit: true
 - ufo-data:
-    branch: dc81b3991bb23f2e63067b7e2851711a23a1839b
+    branch: 7a93c494369820c95aaa5c531e5b337013972244
     commit: true
 - icepack:
     branch: 73136ee8dcdbe378821e540488a5980a03d8abe6

--- a/src/jedi_bundle/config/platforms/nccs_discover.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover.yaml
@@ -16,16 +16,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
       - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
       - module load miniconda/3.9.7
-      - module load ecflow/5.8.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.8.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
       - module load stack-intel/2021.6.0
       - module load stack-intel-oneapi-mpi/2021.6.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.6.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-geos:
     init:
@@ -35,16 +34,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
       - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
       - module load miniconda/3.9.7
-      - module load ecflow/5.8.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.8.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
       - module load stack-intel/2021.6.0
       - module load stack-intel-oneapi-mpi/2021.6.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.6.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -55,16 +53,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
       - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
       - module load miniconda/3.9.7
-      - module load ecflow/5.8.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-gcc-12.1.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.8.0/envs/ue-gcc-12.1.0/install/modulefiles/Core
       - module load stack-gcc/12.1.0
       - module load stack-openmpi/4.1.3
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -74,15 +71,14 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
       - module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
       - module load miniconda/3.9.7
-      - module load ecflow/5.8.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-gcc-12.1.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.8.0/envs/ue-gcc-12.1.0/install/modulefiles/Core
       - module load stack-gcc/12.1.0
       - module load stack-openmpi/4.1.3
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -15,16 +15,15 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.8.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-geos:
     init:
@@ -33,16 +32,15 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.8.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -52,16 +50,15 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.8.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -70,15 +67,14 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.8.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"


### PR DESCRIPTION
Uses modules listed here:

https://github.com/JCSDA/spack-stack/wiki/Post%E2%80%90release-updates-for-spack%E2%80%90stack%E2%80%901.8.0

Which are located on Discover here:
`/discover/nobackup/projects/gmao/advda/swell/jedi_modules`

TODO:
- [x] Compare results with Spack-stack 1.8 version against the Spack-stack 1.7 pinned version (November 19th)
  In other words:
  `/discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_11192024_skylab8`
  vs.
  `/discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_11192024`
  SOCA comparison provided identical results (same compilers) ✅ 



Skylab8 (JCSDA's workflow environment) corresponds to Spack-stack 1.8

FYI @rtodling @metdyn 