### PR TITLE
Use of Icepack as a submodule

### DIFF
--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -51,9 +51,6 @@
 
 
 # Soca
-- icepack:
-    repo_url_name: Icepack
-    default_branch: feature/ecbuild-new
 - soca:
     default_branch: develop
 

--- a/src/jedi_bundle/config/bundles/soca.yaml
+++ b/src/jedi_bundle/config/bundles/soca.yaml
@@ -1,6 +1,5 @@
 optional_repos:
   - crtm
-  - icepack
 
 required_repos:
   - jedicmake

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -47,6 +47,3 @@
 - ufo-data:
     branch: 1a3008b44adbbe50926dd7915fdbb975233084d9
     commit: true
-- icepack:
-    branch: 73136ee8dcdbe378821e540488a5980a03d8abe6
-    commit: true

--- a/src/jedi_bundle/utils/git.py
+++ b/src/jedi_bundle/utils/git.py
@@ -128,8 +128,7 @@ def get_url_and_branch(logger, github_orgs, repo_url_name, default_branch,
             # Check for user branch and return right away if found
             if user_branch != '':
                 if repo_has_branch(logger, github_url, user_branch):
-                    is_tag = False
-                    return repo_url_found, github_url, user_branch, is_tag
+                    return repo_url_found, github_url, user_branch, is_tag, is_commit
 
             # Track first instance of finding the default branch. But do not exit when it's first
             # found so that other organizations can be checked for the user branch.


### PR DESCRIPTION
Adapts to changes in SOCA where Icepack is installed as a submodule rather than a separate package:

https://github.com/JCSDA-internal/soca/pull/1116

I also identified a minor bug while using `user_branch` so this fixes that. This is draft until our JEDI build is updated past January.


@mranst, you should try building with these changes, otherwise it won't build