### PR TITLE
Update sles15 modules to spack-stack 1.9, and update pinned versions to Feb 6

### DIFF
--- a/docs/_platforms/building_jedi_code_on_discover_sles15.md
+++ b/docs/_platforms/building_jedi_code_on_discover_sles15.md
@@ -1,17 +1,17 @@
 # Building JEDI code on Discover (SLES 15)
 
-1) Load the JEDI spack Python modules (These modules will load Python version 3.10):
+1) Load the JEDI spack Python modules (These modules will load Python version 3.11):
 
 ``` bash
 module purge
-source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/bundle-intel-sles15
+source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel_bundle
 ```
 
 2) Load the SLES15 `jedi_bundle` module:
 
 ``` bash
 module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core/
-module load jedi_bundle/sles15_skylab7
+module load jedi_bundle/sles15_skylab9
 ```
 
 3) Create a directory where the source code and build directory will be stored e.g.:
@@ -37,7 +37,7 @@ Once `build.yaml` is configured they way you wish, you can issue `jedi_bundle` a
 jedi_bundle clone configure build.yaml
 ```
 
-6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following:
+6) Then proceed building JEDI using a compute node. First, request interactive nodes with the following: (Note: 1 hour could be insufficient if Discover IO load is high. If that is the case simply request interactive nodes again and submit `make` command with the proper modules loaded):
 
 ``` bash
 salloc --time=1:00:00

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -51,9 +51,6 @@
 
 
 # Soca
-- icepack:
-    repo_url_name: Icepack
-    default_branch: feature/ecbuild-new
 - soca:
     default_branch: develop
 

--- a/src/jedi_bundle/config/bundles/soca.yaml
+++ b/src/jedi_bundle/config/bundles/soca.yaml
@@ -1,6 +1,5 @@
 optional_repos:
   - crtm
-  - icepack
 
 required_repos:
   - jedicmake

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -1,49 +1,49 @@
-# Pinned versions for 2024-11-19
+# Pinned versions for 2025-02-06
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
 - oops:
-    branch: 0efe7bdb5f2b811d0deab966c658632b613b2479
+    branch: 765aeb1204a6999f78cf4fd589074af42cd4700c
     commit: true
 - saber:
-    branch: 0c40b02486dd7989d8b976764f60d087a3d0a3c6
+    branch: b85ece54b9928c9aed0a11b46f7a3a963f78e635
     commit: true
 - ioda:
-    branch: 9e6518f4a185271975be2adb6e5c817710297445
+    branch: cae6614602b415262b10f1f648757c76a657b5af
     commit: true
 - ufo:
-    branch: eae5d628c6c6da1d226f654b943b987256545a12
+    branch: f761f4727b22b58d9a39accd6d7e626c1dd00ad9
     commit: true
 - vader:
-    branch: 14e8bcee16c0fc2dc4d4189b17d5703b193aff45
+    branch: 0792f693148c3d09a166021e6b8c2758cb8a1251
     commit: true
 - fv3:
     branch: ab25dc09d955271f34ca6a3fa83af1093c85d9f7
     commit: true
 - fv3-jedi-lm:
-    branch: 3254bb84c71edca20d86932b0d2f7dde4ab57fe7
+    branch: 5994c385a01236bb9def57dd37b73bec8b5df487
     commit: true
 - femps:
     branch: 4f12677d345e683bf910b5f76f0df120ad27482d
     commit: true
 - fv3-jedi:
-    branch: 48091067068cbda32e96f49aa067d73d9450c146
+    branch: a391d2fd2263056c1ace87b8507960d7b936380a
     commit: true
 - ioda-data:
-    branch: 3c0d231eaa2eaac374a46bdb662d28e3e3a3b559
+    branch: 9d414d76d9859701ed5eb126dddf08e704a1e159
     commit: true
 - fv3-jedi-data:
-    branch: 2085be5f75da3612c3f41d0ec4d68093fcd0fb24
+    branch: effbda720365a4b095114bd97adcd9367b0b34e3
     commit: true
 - soca:
-    branch: fe20d587baf5e6e7a2f4cb2216d5f337eb76f049
+    branch: b4378059d8306aef6fbb80cac536ee3849f6353b
     commit: true
 - iodaconv:
-    branch: 6f87a0f279e836fd604e5b313a25bd1e54bff80e
+    branch: ab99fd23178155458d24ab5cc9ef4d04406cd17c
     commit: true
 - gsw:
     branch: 697cbeb7605d70ed3857664c5f54a5c05346e31f
     commit: true
 - ufo-data:
-    branch: 1a3008b44adbbe50926dd7915fdbb975233084d9
+    branch: ca4e6f544b1330e9977552aff153f33ed178fb72
     commit: true

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -47,6 +47,3 @@
 - ufo-data:
     branch: 1a3008b44adbbe50926dd7915fdbb975233084d9
     commit: true
-- icepack:
-    branch: 73136ee8dcdbe378821e540488a5980a03d8abe6
-    commit: true

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -16,15 +16,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
       - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-geos:
     init:
@@ -34,15 +34,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
       - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -53,15 +53,15 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
       - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -71,14 +71,14 @@ modules:
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
       - module load ecflow/5.11.4
-      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6
-      - module load stack-python/3.10.13
+      - module load stack-python/3.11.7
       - module load jedi-fv3-env
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
-      - module load fms/2023.04
+      - module load fms/2024.02
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -32,7 +32,6 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
       - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -50,7 +50,6 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
       - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -67,7 +67,6 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
       - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-gcc-12.3.0/install/modulefiles/Core
       - module load stack-gcc/12.3.0
       - module load stack-openmpi/4.1.6

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -15,7 +15,6 @@ modules:
       - module purge
       - module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
       - module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
-      - module load ecflow/5.11.4
       - module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.9.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
       - module load stack-intel/2021.10.0
       - module load stack-intel-oneapi-mpi/2021.10.0

--- a/src/jedi_bundle/utils/git.py
+++ b/src/jedi_bundle/utils/git.py
@@ -128,8 +128,7 @@ def get_url_and_branch(logger, github_orgs, repo_url_name, default_branch,
             # Check for user branch and return right away if found
             if user_branch != '':
                 if repo_has_branch(logger, github_url, user_branch):
-                    is_tag = False
-                    return repo_url_found, github_url, user_branch, is_tag
+                    return repo_url_found, github_url, user_branch, is_tag, is_commit
 
             # Track first instance of finding the default branch. But do not exit when it's first
             # found so that other organizations can be checked for the user branch.


### PR DESCRIPTION
## Description

Updates nccs_discover_sles15 module to use spack-stack 1.9, including updating python version to 3.11.

## Dependencies

Waiting on the following PRs:
- [x] waiting on GEOS-ESM/jedi_bundle/pull/58