### PR TITLE
Point to updated GSIBEC 1.3.2

### DIFF
--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -20,7 +20,7 @@
 # Background error models
 - gsibec:
     repo_url_name: GSIbec
-    default_branch: 1.3.1
+    default_branch: 1.3.2
     tag: true
 - saber:
     default_branch: develop


### PR DESCRIPTION
## Description

Point to GSIBEC 1.3.2. This version is zero diff to 1.3.1, but it allows for hybrid to be configured in dual-resolution background error form, just as GSI does.

## Dependencies

None

## Impact

None
