### PR TITLE
Remove reference to fv3 repo

### DIFF
--- a/src/jedi_bundle/clone_jedi_bundle.py
+++ b/src/jedi_bundle/clone_jedi_bundle.py
@@ -226,15 +226,6 @@ def clone_jedi(logger, clone_config):
         if repo == 'jedicmake':
             logger.info(f'Skipping explicit clone of \'{repo}\' since it\'s usually a module. ' +
                         f'If it\'s not a module it will be cloned at configure time.')
-        elif repo == 'fv3':
-            logger.info('Cloning fv3-interface.cmake from the jedi-bundle repo for fv3')
-            found, url_tmp, branch_tmp, \
-                _, _ = get_url_and_branch(logger, github_orgs, 'jedi-bundle',
-                                          'develop', user_branch, False, False)
-            clone_git_file(logger, url_tmp, ['fv3-interface.cmake'], path_to_source, depth=1)
-            logger.info('Cloning fv3.')
-            clone_git_repo(logger, url, branch,
-                           os.path.join(path_to_source, repo), is_tag, is_commit)
         else:
             logger.info(f'Cloning \'{repo}\'.')
             clone_git_repo(logger, url, branch,
@@ -304,12 +295,6 @@ def clone_jedi(logger, clone_config):
                     output_file_open.write(jedi_cmake_line + '\n')
 
             else:
-                # Add include(fv3-interface.cmake) line if repo is fv3
-                if repo == 'fv3':
-                    output_file_open.write(' include(fv3-interface.cmake )\n')
-                    output_file_open.write(f' list( APPEND CMAKE_INSTALL_RPATH '
-                                           '${CMAKE_CURRENT_BINARY_DIR}/fv3 )\n')
-
                 output_file_open.write(package_line + '\n')
                 if cmake != '':
                     output_file_open.write(cmake + '\n')

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -55,9 +55,6 @@
     default_branch: develop
 
 # Fv3-jedi
-- fv3:
-    repo_url_name: GFDL_atmos_cubed_sphere
-    default_branch: release-stable
 - fv3-jedi-lm:
     repo_url_name: fv3-jedi-linearmodel
     default_branch: develop

--- a/src/jedi_bundle/config/bundles/fv3-jedi.yaml
+++ b/src/jedi_bundle/config/bundles/fv3-jedi.yaml
@@ -11,7 +11,6 @@ required_repos:
   - crtm
   - ufo
   - vader
-  - fv3
   - fv3-jedi-lm
   - femps
   - fv3-jedi


### PR DESCRIPTION
## Description

According to latest from JCSDA:

- the fv3 repo (our fork of GFDL_atmos_cubed_sphere) is no longer needed to build fv3-jedi (see: [https://github.com/JCSDA-internal/fv3-jedi/pull/1356](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJCSDA-internal%2Ffv3-jedi%2Fpull%2F1356&data=05%7C02%7Cricardo.todling%40nasa.gov%7C152f253a75184a1f502a08ddb8e93f98%7C7005d45845be48ae8140d43da96dd17b%7C0%7C0%7C638870034142925735%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=aGxxoyuATkflrSXOG8vPLYbNQMugHKoX0i9TF5XXsNo%3D&reserved=0))
- the the fv3 repo and fv3-interface file are no longer required to be part of the bundle (see: [https://github.com/JCSDA-internal/jedi-bundle/pull/111](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJCSDA-internal%2Fjedi-bundle%2Fpull%2F111&data=05%7C02%7Cricardo.todling%40nasa.gov%7C152f253a75184a1f502a08ddb8e93f98%7C7005d45845be48ae8140d43da96dd17b%7C0%7C0%7C638870034142950232%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=Omjeywc%2B%2FtjAsPWftqz1ZWjFAxfUDYvhdwfHTfsfilI%3D&reserved=0))

## Dependencies

If there are PRs that need to be merged before or along with this one, please list them below
Waiting on the following PRs:
- [ ] waiting on GEOS-ESM/repo/pull/<pr_number>
- [ ] waiting on GEOS-ESM/repo/pull/<pr_number>

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

- [ ] repo
- [ ] ...
