### PR TITLE
introduce NAS platforms, take da-utils out, again

### DIFF
--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -31,6 +31,10 @@ jobs:
           printf "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
           git config --global credential.helper "store --file=${HOME}/.git-credentials"
 
+      - name: Debug PAT prefix
+        run: |
+          echo "PAT prefix: $(echo "${{ secrets.JEDI_GH_PAT }}" | cut -c1-6)"
+
       - name: Debug git-credentials presence
         run: |
           ls -l "${HOME}"

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Configure git credentials for private JEDI repos
         run: |
           mkdir -p "${HOME}"
-
-          cat <<'EOF' > "${HOME}/.git-credentials"
-          https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com
-          EOF
-          git config --global credential.helper "store --file=${HOME}/.git-credentials"
+          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
+          git config --global credential.helper "store"
 
       # Install package
       - name: Install JEDI bundle and dependencies

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -36,6 +36,14 @@ jobs:
           ls -l "${HOME}"
           sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
 
+      - name: Debug PAT scopes against GitHub API
+        run: |
+          echo "Querying GitHub API for token scopes..."
+          curl -s -I \
+            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
+            https://api.github.com/user \
+            | grep -i '^X-OAuth-Scopes\|^X-Accepted-OAuth-Scopes\|^Status'
+
       - name: Direct PAT test (debug only)
         run: |
           git ls-remote "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           lfs: true
-          
+
       # Install package
       - name: Install JEDI bundle and dependencies
         run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt .

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -34,14 +34,14 @@ jobs:
       # Install package
       - name: Install JEDI bundle and dependencies
         run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt --user .
-      
+
       - name: Put executables in the path
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
         # Test credentials
       - name: Test git credentials
         run: |
-          git ls-remote https://github.com/YOUR-ORG/jedicmake.git
+          git ls-remote https://github.com/JCSDA-internal/jedi-cmake.git
 
       # Run an application test
       - name: Run JEDI Bundle application test

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -36,13 +36,18 @@ jobs:
           ls -l "${HOME}"
           sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
 
-      - name: Debug PAT access to JCSDA-internal/jedi-cmake via API
+      - name: Debug PAT scopes and repo access
         run: |
-          echo "Checking repo visibility via API..."
-          curl -s -I \
+          echo "Token scopes for /user:"
+          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:X-OAuth-Scopes}\nX-Accepted-OAuth-Scopes: %{header:X-Accepted-OAuth-Scopes}\n' \
             -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
-            https://api.github.com/repos/JCSDA-internal/jedi-cmake \
-            | grep -i '^Status\|^X-RateLimit-Remaining\|^X-GitHub-Request-Id'
+            https://api.github.com/user
+
+          echo
+          echo "Access to JCSDA-internal/jedi-cmake:"
+          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:X-OAuth-Scopes}\nX-Accepted-OAuth-Scopes: %{header:X-Accepted-OAuth-Scopes}\n' \
+            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
+            https://api.github.com/repos/JCSDA-internal/jedi-cmake
 
       - name: Direct PAT test (debug only)
         run: |

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,17 +25,10 @@ jobs:
         with:
           lfs: true
 
-      ## Configure git to access private repos
-      #- name: Configure git credentials for private JEDI repos
-        #run: |
-          #mkdir -p "${HOME}"
-          #printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
-          #git config --global credential.helper "store"
-
       - name: Configure git credentials for private JEDI repos
         run: |
           mkdir -p "${HOME}"
-          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
+          printf "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
           git config --global credential.helper "store --file=${HOME}/.git-credentials"
 
       - name: Debug git-credentials presence
@@ -45,7 +38,7 @@ jobs:
 
       - name: Direct PAT test (debug only)
         run: |
-          git ls-remote "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"
+          git ls-remote "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"
 
       # Test credentials
       - name: Test git credentials

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Debug PAT scopes and repo access
         run: |
           echo "Token scopes for /user:"
-          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:X-OAuth-Scopes}\nX-Accepted-OAuth-Scopes: %{header:X-Accepted-OAuth-Scopes}\n' \
+          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:x-oauth-scopes}\nX-Accepted-OAuth-Scopes: %{header:x-accepted-oauth-scopes}\n' \
             -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
             https://api.github.com/user
 
           echo
           echo "Access to JCSDA-internal/jedi-cmake:"
-          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:X-OAuth-Scopes}\nX-Accepted-OAuth-Scopes: %{header:X-Accepted-OAuth-Scopes}\n' \
+          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:x-oauth-scopes}\nX-Accepted-OAuth-Scopes: %{header:x-accepted-oauth-scopes}\n' \
             -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
             https://api.github.com/repos/JCSDA-internal/jedi-cmake
 

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   buildbundle:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Clone oops bundle
     runs-on: ubuntu-latest
     strategy:
@@ -30,6 +31,11 @@ jobs:
           mkdir -p "${HOME}"
           printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
           git config --global credential.helper "store"
+
+      - name: Debug git-credentials presence
+        run: |
+          ls -l "${HOME}"
+          sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
 
       # Test credentials
       - name: Test git credentials

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -24,22 +24,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           lfs: true
-
-      - name: Set github url and credentials
-        run: |
-          git config --global credential.helper store
-          echo "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com" > ~/.git-credentials
-
-      - name: Direct test via git
-        run: |
-          git ls-remote https://github.com/JCSDA-internal/jedi-cmake.git
-
+          
       # Install package
       - name: Install JEDI bundle and dependencies
-        run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt --user .
-
-      - name: Put executables in the path
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt .
 
       # Run an application test
       - name: Run JEDI Bundle application test
@@ -48,4 +36,3 @@ jobs:
       # Confirm existence of expected file
       - name: Check
         run: ls -l jedi_bundle/oops/CMakeLists.txt
-

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,17 +25,27 @@ jobs:
         with:
           lfs: true
 
-      # Configure git to access private repos
+      ## Configure git to access private repos
+      #- name: Configure git credentials for private JEDI repos
+        #run: |
+          #mkdir -p "${HOME}"
+          #printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
+          #git config --global credential.helper "store"
+
       - name: Configure git credentials for private JEDI repos
         run: |
           mkdir -p "${HOME}"
-          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
-          git config --global credential.helper "store"
+          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
+          git config --global credential.helper "store --file=${HOME}/.git-credentials"
 
       - name: Debug git-credentials presence
         run: |
           ls -l "${HOME}"
           sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
+
+      - name: Direct PAT test (debug only)
+        run: |
+          git ls-remote "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"
 
       # Test credentials
       - name: Test git credentials

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,11 +25,16 @@ jobs:
           lfs: true
 
       # Configure git to access private repos
+      # - name: Configure git credentials for private JEDI repos
+      #   run: |
+      #     mkdir -p "${HOME}"
+      #     printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
+      #     git config --global credential.helper "store"
+      
+      # Configure git to access private repos
       - name: Configure git credentials for private JEDI repos
         run: |
-          mkdir -p "${HOME}"
-          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
-          git config --global credential.helper "store"
+          git config --global url."https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
       # Install package
       - name: Install JEDI bundle and dependencies

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -9,31 +9,32 @@ jobs:
   buildbundle:
     name: Clone oops bundle
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
     steps:
+      # Setup Python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    # Setup Python
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
+      # Clone the code repo
+      - name: Clone code repo
+        uses: actions/checkout@v4
+        with:
+          lfs: true
 
-    # Clone the code repo
-    - name: Clone code repo
-      uses: actions/checkout@v4
-      with:
-        lfs: true
+      # Install package
+      - name: Install JEDI bundle and dependencies
+        run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt --user .
+      - name: Put executables in the path
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    # Install package
-    - name: Install JEDI bundle and dependencies
-      run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt --user .
-    - name: Put executables in the path
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # Run an application test
+      - name: Run JEDI Bundle application test
+        run: jedi_bundle Clone src/jedi_bundle/config/build.yaml
 
-    # Run an application test
-    - name: Run JEDI Bundle application test
-      run: jedi_bundle Clone src/jedi_bundle/config/build.yaml
-
-    # Confirm existence of expected file
-    - name: Check
-      run: ls -l jedi_bundle/oops/CMakeLists.txt
+      # Confirm existence of expected file
+      - name: Check
+        run: ls -l jedi_bundle/oops/CMakeLists.txt

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -36,6 +36,14 @@ jobs:
           ls -l "${HOME}"
           sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
 
+      - name: Debug PAT access to JCSDA-internal/jedi-cmake via API
+        run: |
+          echo "Checking repo visibility via API..."
+          curl -s -I \
+            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
+            https://api.github.com/repos/JCSDA-internal/jedi-cmake \
+            | grep -i '^Status\|^X-RateLimit-Remaining\|^X-GitHub-Request-Id'
+
       - name: Direct PAT test (debug only)
         run: |
           git ls-remote "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,16 +25,16 @@ jobs:
           lfs: true
 
       # Configure git to access private repos
-      # - name: Configure git credentials for private JEDI repos
-      #   run: |
-      #     mkdir -p "${HOME}"
-      #     printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
-      #     git config --global credential.helper "store"
-      
-      # Configure git to access private repos
       - name: Configure git credentials for private JEDI repos
         run: |
-          git config --global url."https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com/".insteadOf "https://github.com/"
+          mkdir -p "${HOME}"
+          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
+          git config --global credential.helper "store"
+
+      # Test credentials
+      - name: Test git credentials
+        run: |
+          git ls-remote https://github.com/JCSDA-internal/jedi-cmake.git
 
       # Install package
       - name: Install JEDI bundle and dependencies
@@ -43,11 +43,6 @@ jobs:
       - name: Put executables in the path
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-        # Test credentials
-      - name: Test git credentials
-        run: |
-          git ls-remote https://github.com/JCSDA-internal/jedi-cmake.git
-
       # Run an application test
       - name: Run JEDI Bundle application test
         run: jedi_bundle Clone src/jedi_bundle/config/build.yaml
@@ -55,3 +50,4 @@ jobs:
       # Confirm existence of expected file
       - name: Check
         run: ls -l jedi_bundle/oops/CMakeLists.txt
+

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-
 jobs:
   buildbundle:
     name: Clone oops bundle
@@ -29,14 +28,20 @@ jobs:
       - name: Configure git credentials for private JEDI repos
         run: |
           mkdir -p "${HOME}"
-          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\nhttps:${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}\n" > "${HOME}/.git-credentials"
+          printf "https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
           git config --global credential.helper "store"
 
       # Install package
       - name: Install JEDI bundle and dependencies
         run: python -m pip install --use-deprecated=legacy-resolver -r requirements.txt --user .
+      
       - name: Put executables in the path
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+        # Test credentials
+      - name: Test git credentials
+        run: |
+          git ls-remote https://github.com/YOUR-ORG/jedicmake.git
 
       # Run an application test
       - name: Run JEDI Bundle application test

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -31,10 +31,6 @@ jobs:
           printf "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
           git config --global credential.helper "store --file=${HOME}/.git-credentials"
 
-      - name: Debug PAT prefix
-        run: |
-          echo "PAT prefix: $(echo "${{ secrets.JEDI_GH_PAT }}" | cut -c1-6)"
-
       - name: Debug git-credentials presence
         run: |
           ls -l "${HOME}"

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,36 +25,11 @@ jobs:
         with:
           lfs: true
 
-      - name: Configure git credentials for private JEDI repos
+      - name: Configure git to use PAT for GitHub
         run: |
-          mkdir -p "${HOME}"
-          printf "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com\n" > "${HOME}/.git-credentials"
-          git config --global credential.helper "store --file=${HOME}/.git-credentials"
+          git config --global url."https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
-      - name: Debug git-credentials presence
-        run: |
-          ls -l "${HOME}"
-          sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
-
-      - name: Debug PAT scopes and repo access
-        run: |
-          echo "Token scopes for /user:"
-          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:x-oauth-scopes}\nX-Accepted-OAuth-Scopes: %{header:x-accepted-oauth-scopes}\n' \
-            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
-            https://api.github.com/user
-
-          echo
-          echo "Access to JCSDA-internal/jedi-cmake:"
-          curl -s -o /dev/null -w 'HTTP: %{http_code}\nX-OAuth-Scopes: %{header:x-oauth-scopes}\nX-Accepted-OAuth-Scopes: %{header:x-accepted-oauth-scopes}\n' \
-            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
-            https://api.github.com/repos/JCSDA-internal/jedi-cmake
-
-      - name: Direct PAT test (debug only)
-        run: |
-          git ls-remote "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"
-
-      # Test credentials
-      - name: Test git credentials
+      - name: Direct test via git
         run: |
           git ls-remote https://github.com/JCSDA-internal/jedi-cmake.git
 

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -21,9 +21,19 @@ jobs:
 
       # Clone the code repo
       - name: Clone code repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
+
+      # Configure git to access private repos
+      - name: Configure git credentials for private JEDI repos
+        run: |
+          mkdir -p "${HOME}"
+
+          cat <<'EOF' > "${HOME}/.git-credentials"
+          https://${{ secrets.JEDI_GH_USER }}:${{ secrets.JEDI_GH_PAT }}@github.com
+          EOF
+          git config --global credential.helper "store --file=${HOME}/.git-credentials"
 
       # Install package
       - name: Install JEDI bundle and dependencies

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           lfs: true
 
-      - name: Configure git to use PAT for GitHub
+      - name: Set github url and credentials
         run: |
-          git config --global url."https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/".insteadOf "https://github.com/"
+          git config --global credential.helper store
+          echo "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com" > ~/.git-credentials
 
       - name: Direct test via git
         run: |

--- a/.github/workflows/clone_a_jedi_bundle.yml
+++ b/.github/workflows/clone_a_jedi_bundle.yml
@@ -36,14 +36,6 @@ jobs:
           ls -l "${HOME}"
           sed 's/\(https:\/\/\).*\(:\).*\(@github.com\)/\1USER\2***\3/' "${HOME}/.git-credentials" || echo "no creds"
 
-      - name: Debug PAT scopes against GitHub API
-        run: |
-          echo "Querying GitHub API for token scopes..."
-          curl -s -I \
-            -H "Authorization: token ${{ secrets.JEDI_GH_PAT }}" \
-            https://api.github.com/user \
-            | grep -i '^X-OAuth-Scopes\|^X-Accepted-OAuth-Scopes\|^Status'
-
       - name: Direct PAT test (debug only)
         run: |
           git ls-remote "https://x-access-token:${{ secrets.JEDI_GH_PAT }}@github.com/JCSDA-internal/jedi-cmake.git"

--- a/.github/workflows/python_coding_norms.yml
+++ b/.github/workflows/python_coding_norms.yml
@@ -8,26 +8,29 @@ jobs:
   pycodestyle:
     name: Check Python Coding Norms
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+
     steps:
+      # Setup Python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    # Setup Python
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
+      # Update conda
+      - name: Update conda
+        run: conda update -n base -c defaults conda
 
-    # Update conda
-    - name: Update conda
-      run: conda update -n base -c defaults conda
+      # Install pycodestyle
+      - name: Install pycodestyle
+        run: conda install -c conda-forge pycodestyle
 
-    # Install pycodestyle
-    - name: Install pycodestyle
-      run: conda install -c conda-forge pycodestyle
+      # Clone the code repo
+      - name: Clone code repo
+        uses: actions/checkout@v2
 
-    # Clone the code repo
-    - name: Clone code repo
-      uses: actions/checkout@v2
-
-    # Run python codestyle
-    - name: Run python codestyle
-      run: $CONDA/bin/python3 pycodestyle_run.py
+      # Run python codestyle
+      - name: Run python codestyle
+        run: $CONDA/bin/python3 pycodestyle_run.py

--- a/src/jedi_bundle/__init__.py
+++ b/src/jedi_bundle/__init__.py
@@ -9,4 +9,4 @@ import os
 build_directory = os.path.dirname(__file__)
 
 # Set the version for jedi_bundle
-__version__ = '1.0.30'
+__version__ = '1.0.40'

--- a/src/jedi_bundle/config/build.yaml
+++ b/src/jedi_bundle/config/build.yaml
@@ -2,9 +2,9 @@ clone_options:
   path_to_source: jedi_bundle
   user_branch: ''
   github_orgs:
+    - JCSDA
     - JCSDA-internal
     - GEOS-ESM
-    - NOAA-EMC
   bundles:
     - oops
   extra_repos: [gsibec]

--- a/src/jedi_bundle/config/build.yaml
+++ b/src/jedi_bundle/config/build.yaml
@@ -3,7 +3,6 @@ clone_options:
   user_branch: ''
   github_orgs:
     - JCSDA-internal
-    - JCSDA
     - GEOS-ESM
     - NOAA-EMC
   bundles:
@@ -21,4 +20,4 @@ configure_options:
   external_modules: false
 
 make_options:
-  cores_to_use_for_make: 6
+  cores_to_use_for_make: 24

--- a/src/jedi_bundle/config/bundles/da-utils.yaml
+++ b/src/jedi_bundle/config/bundles/da-utils.yaml
@@ -1,5 +1,0 @@
-required_repos:
-  - jedicmake
-  - oops
-  - ioda
-  - da-utils

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -41,6 +41,3 @@
 - ufo-data:
     branch: 532370c47e6cf444b890fdf24d8647c97f0ebe62
     commit: true
-- da-utils:
-    branch: 1f122df3e6b3cc28db5020bfe81a1bfd72313d08
-    commit: true

--- a/src/jedi_bundle/config/platforms/nas_aitken.yaml
+++ b/src/jedi_bundle/config/platforms/nas_aitken.yaml
@@ -1,0 +1,74 @@
+platform_name: nas_aitken
+is_it_me:
+  - command: 'hostname'
+    contains: afe
+crtm_coeffs_path: '/nobackup/dardag/SwellStaticFiles/jedi/crtm_coefficients/'
+crtm_coeffs_version: '2.4.1_skylab_4.0'
+modules:
+  default_modules: intel-oneapi
+  intel-oneapi:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-oneapi-2024.2.0/install/modulefiles/Core
+      - module load stack-oneapi/2024.2.0
+      - module load stack-mpt/2.30
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module unload -f gsibec crtm
+      - module load gmao-swell-env/1.0.0
+      - module load sp/2.5.0
+    configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  intel-oneapi-geos:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-oneapi-2024.2.0/install/modulefiles/Core
+      - module load stack-oneapi/2024.2.0
+      - module load stack-mpt/2.30
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+      - module load cmake esmf/8.8.0 gftl gftl-shared pflogger fargparse udunits
+    configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  gnu:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module load stack-gcc/12.3.0
+      - module load stack-openmpi/4.1.8
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
+  gnu-geos:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module load stack-gcc/12.3.0
+      - module load stack-openmpi/4.1.8
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nas_pleiades.yaml
+++ b/src/jedi_bundle/config/platforms/nas_pleiades.yaml
@@ -1,0 +1,74 @@
+platform_name: nas_pleiades
+is_it_me:
+  - command: 'hostname'
+    contains: pfe
+crtm_coeffs_path: '/nobackup/dardag/SwellStaticFiles/jedi/crtm_coefficients/'
+crtm_coeffs_version: '2.4.1_skylab_4.0'
+modules:
+  default_modules: intel-oneapi
+  intel-oneapi:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-oneapi-2024.2.0/install/modulefiles/Core
+      - module load stack-oneapi/2024.2.0
+      - module load stack-mpt/2.30
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module unload -f gsibec crtm
+      - module load gmao-swell-env/1.0.0
+      - module load sp/2.5.0
+    configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  intel-oneapi-geos:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-oneapi-2024.2.0/install/modulefiles/Core
+      - module load stack-oneapi/2024.2.0
+      - module load stack-mpt/2.30
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+      - module load cmake esmf/8.8.0 gftl gftl-shared pflogger fargparse udunits
+    configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
+  gnu:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module load stack-gcc/12.3.0
+      - module load stack-openmpi/4.1.8
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
+  gnu-geos:
+    init:
+      - source /usr/share/modules/init/bash
+    load:
+      - module purge
+      - module use /nobackup/gmao_SIteam/modulefiles
+      - module use /nobackup/gmao_SIteam/spack-stack/spack-stack-1.9.3/envs/ue-gcc-12.3.0/install/modulefiles/Core
+      - module load stack-gcc/12.3.0
+      - module load stack-openmpi/4.1.8
+      - module load stack-python/3.11.7
+      - module load jedi-fv3-env
+      - module load soca-env
+      - module load gmao-swell-env/1.0.0
+      - module unload -f gsibec crtm
+      - module load sp/2.5.0
+      - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
+    configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"


### PR DESCRIPTION
Introduces `aitken` and `pleiades` (this one will get decommisioned soon). 

~Takes `JCSDA` out from default `build.yaml`.~ unfortunately we couldn't figure this out

`da-utils` can't be installed with `iodaconv`, so for now let's take it out.