### PR TITLE
Change SP to IP lib; updated GSIBEC accordingly

### DIFF
--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -20,7 +20,7 @@
 # Background error models
 - gsibec:
     repo_url_name: GSIbec
-    default_branch: 1.3.2
+    default_branch: 1.4.1
     tag: true
 - saber:
     default_branch: develop

--- a/src/jedi_bundle/config/platforms/nas_aitken.yaml
+++ b/src/jedi_bundle/config/platforms/nas_aitken.yaml
@@ -20,7 +20,7 @@ modules:
       - module load soca-env
       - module unload -f gsibec crtm
       - module load gmao-swell-env/1.0.0
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-oneapi-geos:
     init:
@@ -36,7 +36,7 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load cmake esmf/8.8.0 gftl gftl-shared pflogger fargparse udunits
     configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -53,7 +53,7 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -69,6 +69,6 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nas_pleiades.yaml
+++ b/src/jedi_bundle/config/platforms/nas_pleiades.yaml
@@ -20,7 +20,7 @@ modules:
       - module load soca-env
       - module unload -f gsibec crtm
       - module load gmao-swell-env/1.0.0
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-oneapi-geos:
     init:
@@ -36,7 +36,7 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load cmake esmf/8.8.0 gftl gftl-shared pflogger fargparse udunits
     configure: -DMPIEXEC_EXECUTABLE="/nasa/hpe/mpt/2.30_rhel810/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -53,7 +53,7 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -69,6 +69,6 @@ modules:
       - module load soca-env
       - module load gmao-swell-env/1.0.0
       - module unload -f gsibec crtm
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"

--- a/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
+++ b/src/jedi_bundle/config/platforms/nccs_discover_sles15.yaml
@@ -24,7 +24,7 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-geos:
     init:
@@ -42,7 +42,7 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2021/mpi/2021.10.0/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-oneapi:
@@ -61,7 +61,7 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   intel-oneapi-geos:
     init:
@@ -79,7 +79,7 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load cmake esmf/8.8.0 gftl gftl-shared pflogger fargparse udunits
     configure: -DMPIEXEC_EXECUTABLE="/usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpirun" -DMPIEXEC_NUMPROC_FLAG="-np"
   gnu:
@@ -98,7 +98,7 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"
   gnu-geos:
     init:
@@ -116,6 +116,6 @@ modules:
       - module load gmao-swell-env/1.0.0
       - module unload gsibec crtm fms
       - module load fms/2024.02
-      - module load sp/2.5.0
+      - module load ip/5.1.0
       - module load esmf python py-pyyaml py-numpy pflogger fargparse zlib-ng cmake
     configure: -DMPIEXEC_EXECUTABLE="/usr/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"


### PR DESCRIPTION
## Description

This is a zero-diff change that replaces the SP lib w/ IP; this the spectral transform library used by  GSIBEC, thus the later changes accordingly.

## Dependencies

This PR can only be taken once the following PR's have gone in:

- [ ] waiting on https://github.com/JCSDA-internal/saber/pull/1194
- [ ] waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/1460

## Impact

None.

