### PR TITLE
gnu compilation fix for gsibec

### DIFF
--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -20,7 +20,7 @@
 # Background error models
 - gsibec:
     repo_url_name: GSIbec
-    default_branch: 1.4.1
+    default_branch: 1.4.2
     tag: true
 - saber:
     default_branch: develop


### PR DESCRIPTION
## Description

Sorry, but this has a fix for GNU compilation needed by JCSDA (worked in my Matt T).

## Dependencies

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

-  https://github.com/GEOS-ESM/GSIbec/releases/tag/v1.4.2

