### PR TITLE
Add bufr-query to bundles

### DIFF
--- a/docs/_platforms/building_jedi_code_on_discover_sles15.md
+++ b/docs/_platforms/building_jedi_code_on_discover_sles15.md
@@ -4,7 +4,7 @@
 
 ``` bash
 module purge
-source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel_bundle
+source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel
 ```
 
 2) Load the SLES15 `jedi_bundle` module:

--- a/src/jedi_bundle/config/build.yaml
+++ b/src/jedi_bundle/config/build.yaml
@@ -5,6 +5,7 @@ clone_options:
     - JCSDA-internal
     - JCSDA
     - GEOS-ESM
+    - NOAA-EMC
   bundles:
     - oops
   extra_repos: [gsibec]

--- a/src/jedi_bundle/config/bundles/bufr-query.yaml
+++ b/src/jedi_bundle/config/bundles/bufr-query.yaml
@@ -1,0 +1,2 @@
+required_repos:
+  - bufr-query

--- a/src/jedi_bundle/config/bundles/build-order.yaml
+++ b/src/jedi_bundle/config/bundles/build-order.yaml
@@ -26,6 +26,8 @@
     default_branch: develop
 
 # Observation operators
+- bufr-query:
+    default_branch: develop
 - ioda-data:
     default_branch: develop
 - ioda:

--- a/src/jedi_bundle/config/pinned_versions.yaml
+++ b/src/jedi_bundle/config/pinned_versions.yaml
@@ -8,6 +8,9 @@
 - saber:
     branch: 9794b4a56dc17ea68e50d9b4a01fdb974e018299
     commit: true
+- bufr-query:
+    branch: 563d7b3c4b5ce6cc679ee45547edd1f0bd4615ef
+    commit: true
 - ioda:
     branch: 0f02aadc22341fdb4dbb8e5eed13c4889e8ce487
     commit: true


### PR DESCRIPTION
I was surprised at how easy this was to implement but I'm pretty sure it works. I have a test build under
`/discover/nobackup/manstett/SwellExperiments/jedi_build`

We can change the swell modules file to include this, but for testing purposes, the steps to use bufr-query from this are:
`source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel`
`module unload bufr-query`

`export PYTHONPATH=/discover/nobackup/manstett/SwellExperiments/jedi_build/build-intel-release/lib/python3.11/site-packages/:$PYTHONPATH`

This should allow you to `import bufr` from python. The executables such as `bufr2netcdf.x` are located in 
`/discover/nobackup/manstett/SwellExperiments/jedi_build/build-intel-release/bin`