### PR TITLE
Add workflow to update module on Discover

### DIFF
--- a/.github/workflows/update_module_discover.yml
+++ b/.github/workflows/update_module_discover.yml
@@ -1,0 +1,17 @@
+name: Update the jedi_bundle Module on Discover
+
+on:
+  push:
+    branches:
+      - develop
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell:
+      bash
+
+jobs:
+  update-module-discover:
+    uses: GEOS-ESM/CI-workflows/.github/workflows/jedi_bundle_update_discover.yml@main


### PR DESCRIPTION
## Description

This is a concept for a workflow that would update the module for jedi_bundle on Discover, upon merge to develop. I have not tested this as I'm not sure how to, but theoretically I think this should work.